### PR TITLE
Add nth prime functionality to CLI and library

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ List primes up to a limit and save to CSV:
 python prime_cli.py list 100 --csv primes.csv
 ```
 
+Find the n-th prime number:
+
+```bash
+python prime_cli.py nth 10
+```
+
 ### Running tests
 
 Install `pytest` and run:

--- a/prime.py
+++ b/prime.py
@@ -66,3 +66,21 @@ def sieve_primes(limit: int):
             start = num * num
             sieve[start:limit + 1:step] = [False] * len(range(start, limit + 1, step))
     return [i for i, prime in enumerate(sieve) if prime]
+
+
+def nth_prime(n: int) -> int:
+    """Return the ``n``-th prime number (1-indexed)."""
+    if n < 1:
+        raise ValueError("n must be >= 1")
+
+    # Estimate an upper bound for the n-th prime using the prime number theorem
+    if n < 6:
+        limit = 15
+    else:
+        limit = int(n * (math.log(n) + math.log(math.log(n)))) + 3
+
+    primes = sieve_primes(limit)
+    while len(primes) < n:
+        limit *= 2
+        primes = sieve_primes(limit)
+    return primes[n - 1]

--- a/prime_cli.py
+++ b/prime_cli.py
@@ -38,6 +38,10 @@ def cmd_count(args):
     print(prime.prime_pi(args.limit))
 
 
+def cmd_nth(args):
+    print(prime.nth_prime(args.n))
+
+
 def build_parser():
     parser = argparse.ArgumentParser(description="Prime utility CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -64,6 +68,10 @@ def build_parser():
     p_count = subparsers.add_parser("count", help="Count primes up to a limit")
     p_count.add_argument("limit", type=int)
     p_count.set_defaults(func=cmd_count)
+
+    p_nth = subparsers.add_parser("nth", help="Show the n-th prime")
+    p_nth.add_argument("n", type=int)
+    p_nth.set_defaults(func=cmd_nth)
 
     return parser
 

--- a/tests/test_prime.py
+++ b/tests/test_prime.py
@@ -32,3 +32,9 @@ def test_prime_factors():
 
 def test_sieve_primes():
     assert prime.sieve_primes(10) == [2, 3, 5, 7]
+
+
+def test_nth_prime():
+    assert prime.nth_prime(1) == 2
+    assert prime.nth_prime(5) == 11
+    assert prime.nth_prime(100) == 541


### PR DESCRIPTION
## Summary
- implement `nth_prime` function using `sieve_primes`
- extend CLI with new `nth` subcommand
- document the nth command in README
- test nth_prime with several values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684446668534832595e9941d0ff2d9c5