### PR TITLE
Add segmented sieve algorithm and CLI options

### DIFF
--- a/benchmark_primes.py
+++ b/benchmark_primes.py
@@ -10,6 +10,8 @@ def main(limit: int, method: str):
     start = time.perf_counter()
     if method == "sieve":
         prime.sieve_primes(limit)
+    elif method == "segmented":
+        prime.segmented_sieve(limit)
     else:
         list(prime.generate_primes(limit))
     duration = time.perf_counter() - start
@@ -19,6 +21,11 @@ def main(limit: int, method: str):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Benchmark prime generation methods")
     parser.add_argument("limit", type=int, help="Upper limit for prime calculation")
-    parser.add_argument("--method", choices=["trial", "sieve"], default="trial", help="Generation method")
+    parser.add_argument(
+        "--method",
+        choices=["trial", "sieve", "segmented"],
+        default="trial",
+        help="Generation method",
+    )
     args = parser.parse_args()
     main(args.limit, args.method)

--- a/prime.py
+++ b/prime.py
@@ -66,3 +66,31 @@ def sieve_primes(limit: int):
             start = num * num
             sieve[start:limit + 1:step] = [False] * len(range(start, limit + 1, step))
     return [i for i, prime in enumerate(sieve) if prime]
+
+
+def segmented_sieve(limit: int, segment_size: int = 100000):
+    """Generate primes up to ``limit`` using a segmented sieve."""
+    if limit < 2:
+        return []
+
+    sqrt_limit = int(math.sqrt(limit))
+    base_primes = sieve_primes(sqrt_limit)
+    primes = base_primes.copy()
+
+    low = sqrt_limit + 1
+    high = low + segment_size - 1
+    while low <= limit:
+        if high > limit:
+            high = limit
+        mark = [True] * (high - low + 1)
+        for p in base_primes:
+            start = max(p * p, ((low + p - 1) // p) * p)
+            for j in range(start, high + 1, p):
+                mark[j - low] = False
+        for i in range(low, high + 1):
+            if mark[i - low]:
+                primes.append(i)
+        low = high + 1
+        high = low + segment_size - 1
+
+    return primes

--- a/prime_cli.py
+++ b/prime_cli.py
@@ -9,7 +9,12 @@ def cmd_is_prime(args):
 
 
 def cmd_list(args):
-    primes = list(prime.generate_primes(args.limit))
+    if args.method == "sieve":
+        primes = prime.sieve_primes(args.limit)
+    elif args.method == "segmented":
+        primes = prime.segmented_sieve(args.limit)
+    else:
+        primes = list(prime.generate_primes(args.limit))
     if args.csv:
         with open(args.csv, 'w', newline='') as f:
             writer = csv.writer(f)
@@ -20,7 +25,12 @@ def cmd_list(args):
 
 
 def cmd_range(args):
-    primes = list(prime.primes_in_range(args.start, args.end))
+    if args.method == "sieve":
+        primes = [p for p in prime.sieve_primes(args.end) if p >= args.start]
+    elif args.method == "segmented":
+        primes = [p for p in prime.segmented_sieve(args.end) if p >= args.start]
+    else:
+        primes = list(prime.primes_in_range(args.start, args.end))
     if args.csv:
         with open(args.csv, 'w', newline='') as f:
             writer = csv.writer(f)
@@ -49,12 +59,24 @@ def build_parser():
     p_list = subparsers.add_parser("list", help="List primes up to a limit")
     p_list.add_argument("limit", type=int)
     p_list.add_argument("--csv", type=str, help="Output CSV file path")
+    p_list.add_argument(
+        "--method",
+        choices=["trial", "sieve", "segmented"],
+        default="trial",
+        help="Generation method",
+    )
     p_list.set_defaults(func=cmd_list)
 
     p_range = subparsers.add_parser("range", help="List primes in a range")
     p_range.add_argument("start", type=int)
     p_range.add_argument("end", type=int)
     p_range.add_argument("--csv", type=str, help="Output CSV file path")
+    p_range.add_argument(
+        "--method",
+        choices=["trial", "sieve", "segmented"],
+        default="trial",
+        help="Generation method",
+    )
     p_range.set_defaults(func=cmd_range)
 
     p_factors = subparsers.add_parser("factors", help="Prime factors of a number")

--- a/tests/test_prime.py
+++ b/tests/test_prime.py
@@ -32,3 +32,7 @@ def test_prime_factors():
 
 def test_sieve_primes():
     assert prime.sieve_primes(10) == [2, 3, 5, 7]
+
+
+def test_segmented_sieve_matches_sieve():
+    assert prime.segmented_sieve(1000) == prime.sieve_primes(1000)


### PR DESCRIPTION
## Summary
- implement `segmented_sieve` in `prime.py`
- allow choosing prime generation method via `--method` in CLI
- benchmark new segmented sieve option
- test that segmented sieve output matches the normal sieve

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844466bbb408325ab1725bed29ceb5c