### PR TITLE
Add AI and login improvements to Chomp

### DIFF
--- a/webapp/chomp/index.html
+++ b/webapp/chomp/index.html
@@ -8,7 +8,8 @@
 <body>
     <h1>Chomp</h1>
     <div id="login" class="overlay">
-        <input id="player-name" placeholder="Enter your name">
+        <input id="player1-name" placeholder="Player 1 name">
+        <input id="player2-name" placeholder="Player 2 name or 'Computer'">
         <button onclick="startGame()">Start</button>
     </div>
     <div id="game-container" style="display:none;">

--- a/webapp/chomp/script.js
+++ b/webapp/chomp/script.js
@@ -3,6 +3,7 @@ const cols = 6;
 let board = [];
 let currentPlayer = 0; // 0 or 1
 let players = [];
+let againstComputer = false;
 
 function initBoard() {
     board = [];
@@ -36,6 +37,10 @@ function renderBoard() {
 function onCellClick(event) {
     const r = parseInt(event.target.dataset.row);
     const c = parseInt(event.target.dataset.col);
+    makeMove(r, c);
+}
+
+function makeMove(r, c) {
     if (!board[r][c]) return;
     for (let i = r; i < rows; i++) {
         for (let j = c; j < cols; j++) {
@@ -50,6 +55,9 @@ function onCellClick(event) {
         currentPlayer = 1 - currentPlayer;
         updateStatus();
         renderBoard();
+        if (againstComputer && players[currentPlayer] === 'Computer') {
+            setTimeout(computerMove, 300);
+        }
     }
 }
 
@@ -71,6 +79,9 @@ function endGame(winner) {
     updateRatings(winner);
     populateLeaderboard();
     document.querySelectorAll('.cell').forEach(c => c.onclick = null);
+    // show login for next game
+    document.getElementById('game-container').style.display = 'none';
+    document.getElementById('login').style.display = 'block';
 }
 
 function resetGame() {
@@ -80,14 +91,20 @@ function resetGame() {
 }
 
 function startGame() {
-    const name = document.getElementById('player-name').value.trim();
-    if (!name) return;
-    players = [name, 'Computer'];
+    const name1 = document.getElementById('player1-name').value.trim();
+    let name2 = document.getElementById('player2-name').value.trim();
+    if (!name1) return;
+    if (!name2) name2 = 'Computer';
+    players = [name1, name2];
+    againstComputer = name2.toLowerCase() === 'computer';
     currentPlayer = 0;
     document.getElementById('login').style.display = 'none';
     document.getElementById('game-container').style.display = 'block';
     initBoard();
     updateStatus();
+    if (againstComputer && players[currentPlayer] === 'Computer') {
+        setTimeout(computerMove, 300);
+    }
 }
 
 async function updateRatings(winnerIndex) {
@@ -110,6 +127,38 @@ async function populateLeaderboard() {
         li.innerText = `${entry.name}: ${entry.rating}`;
         list.appendChild(li);
     }
+}
+
+function cellsRemainingAfterMove(r, c) {
+    let count = 0;
+    for (let i = 0; i < rows; i++) {
+        for (let j = 0; j < cols; j++) {
+            if (!board[i][j]) continue;
+            if (i >= r && j >= c) continue;
+            count++;
+        }
+    }
+    return count + ((r === 0 && c === 0) ? 0 : 1); // include poison unless taken
+}
+
+function computerMove() {
+    const moves = [];
+    const total = board.flat().filter(Boolean).length;
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+            if (!board[r][c]) continue;
+            if (r === 0 && c === 0 && total > 1) continue; // avoid losing
+            moves.push({ r, c, remain: cellsRemainingAfterMove(r, c) });
+        }
+    }
+    if (moves.length === 0) {
+        makeMove(0, 0);
+        return;
+    }
+    moves.sort((a, b) => a.remain - b.remain);
+    const best = moves.filter(m => m.remain === moves[0].remain);
+    const choice = best[Math.floor(Math.random() * best.length)];
+    makeMove(choice.r, choice.c);
 }
 
 window.onload = populateLeaderboard;


### PR DESCRIPTION
## Summary
- allow entering both player names
- show login screen after each match to update leaderboard
- add computer opponent with a simple strategy

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845acb7cd5483258e8b3cd85ec22bd9